### PR TITLE
增加了idle的开机自启

### DIFF
--- a/src/experimental/PFC/PFC_idle/idle_chat.py
+++ b/src/experimental/PFC/PFC_idle/idle_chat.py
@@ -8,21 +8,16 @@ from datetime import datetime
 from src.common.logger_manager import get_logger
 from src.config.config import global_config
 from src.chat.models.utils_model import LLMRequest
-from src.chat.message_receive.chat_stream import chat_manager, ChatManager
-from src.chat.person_info.person_info import person_info_manager
-from src.chat.person_info.relationship_manager import relationship_manager
-from src.chat.utils.chat_message_builder import build_readable_messages
+from src.chat.message_receive.chat_stream import chat_manager
+from src.chat.message_receive.chat_stream import ChatStream
 
 # from ...schedule.schedule_generator import bot_schedule
 from ..chat_observer import ChatObserver
 from ..message_sender import DirectMessageSender
-from src.chat.message_receive.chat_stream import ChatStream
 from ..pfc_relationship import PfcRepationshipTranslator, PfcRelationshipUpdater
-from maim_message import UserInfo, Seg
+from maim_message import Seg
 from rich.traceback import install
-from ..observation_info import ObservationInfo
 from ..pfc_utils import build_chat_history_text
-from src.common.database import db # 新增导入
 from bson.decimal128 import Decimal128 # 新增导入
 from .idle_weight import calculate_user_weight, calculate_base_trigger_probability, process_instances_weights, find_max_relationship_user, get_user_relationship_data
 

--- a/src/experimental/PFC/PFC_idle/idle_chat.py
+++ b/src/experimental/PFC/PFC_idle/idle_chat.py
@@ -186,13 +186,29 @@ class IdleChat:
                     # 获取关系数据
                     try:
                         platform = "qq"  # 假设用户来自QQ平台
-                        rel_value, rel_level_num, rel_level_name = await relationship_manager.get_relationship_data(platform, instance.private_name)
-                        logger.debug(f"实例 {instance.private_name} 的关系数据: 值={rel_value:.2f}, 等级={rel_level_name}")
+                        # 获取关系值
+                        person_id = person_info_manager.get_person_id(platform, instance.private_name)
+                        rel_value = await person_info_manager.get_value(person_id, "relationship_value")
+                        # 确保关系值是浮点数
+                        if isinstance(rel_value, Decimal128):
+                            rel_value = float(rel_value.to_decimal())
+                        elif rel_value is None:
+                            rel_value = 0.0
+                        else:
+                            rel_value = float(rel_value)
+                        
+                        # 计算关系等级
+                        rel_level_num = relationship_manager.calculate_level_num(rel_value)
+                        relationship_level = ["厌恶", "冷漠", "一般", "友好", "喜欢", "依赖"]
+                        rel_level_name = relationship_level[rel_level_num]
+                        
+                        logger.info(f"[私聊][{instance.private_name}]关系值: {rel_value:.2f}, 关系等级: {rel_level_name}")
+                        relationship_description = rel_level_name
                     except Exception as e:
-                        logger.warning(f"获取实例 {instance.private_name} 的关系数据失败: {str(e)}")
-                        # 使用默认值
-                        rel_level_num = 2
-                        rel_value = 0.0
+                        logger.error(f"[私聊][{instance.private_name}]获取关系数据失败: {str(e)}")
+                        logger.error(traceback.format_exc())
+                        # 使用默认关系描述
+                        relationship_description = "普通"
                     
                     # 记录实例信息
                     instances_with_rel.append({
@@ -517,7 +533,22 @@ class IdleChat:
             # 获取关系数据
             try:
                 platform = "qq"  # 假设用户来自QQ平台
-                rel_value, rel_level_num, rel_level_name = await relationship_manager.get_relationship_data(platform, self.private_name)
+                # 获取关系值
+                person_id = person_info_manager.get_person_id(platform, self.private_name)
+                rel_value = await person_info_manager.get_value(person_id, "relationship_value")
+                # 确保关系值是浮点数
+                if isinstance(rel_value, Decimal128):
+                    rel_value = float(rel_value.to_decimal())
+                elif rel_value is None:
+                    rel_value = 0.0
+                else:
+                    rel_value = float(rel_value)
+                
+                # 计算关系等级
+                rel_level_num = relationship_manager.calculate_level_num(rel_value)
+                relationship_level = ["厌恶", "冷漠", "一般", "友好", "喜欢", "依赖"]
+                rel_level_name = relationship_level[rel_level_num]
+                
                 logger.info(f"[私聊][{self.private_name}]关系值: {rel_value:.2f}, 关系等级: {rel_level_name}")
                 relationship_description = rel_level_name
             except Exception as e:

--- a/src/experimental/PFC/PFC_idle/idle_chat.py
+++ b/src/experimental/PFC/PFC_idle/idle_chat.py
@@ -1,6 +1,5 @@
-# TODO: 开机自启，遍历所有可发起的聊天流，而不是等待 PFC 实例结束
 # TODO: 优化 idle 逻辑 增强其与 PFC 模式的联动
-from typing import Optional, Dict, Set
+from typing import Optional, Dict, Set, List
 import asyncio
 import time
 import random
@@ -9,8 +8,7 @@ from datetime import datetime
 from src.common.logger_manager import get_logger
 from src.config.config import global_config
 from src.chat.models.utils_model import LLMRequest
-
-# from src.plugins.utils.prompt_builder import global_prompt_manager
+from src.chat.message_receive.chat_stream import chat_manager, ChatManager
 from src.chat.person_info.person_info import person_info_manager
 from src.chat.person_info.relationship_manager import relationship_manager
 from src.chat.utils.chat_message_builder import build_readable_messages
@@ -18,15 +16,15 @@ from src.chat.utils.chat_message_builder import build_readable_messages
 # from ...schedule.schedule_generator import bot_schedule
 from ..chat_observer import ChatObserver
 from ..message_sender import DirectMessageSender
-from src.chat.message_receive.chat_stream import ChatStream, chat_manager
+from src.chat.message_receive.chat_stream import ChatStream
+from ..pfc_relationship import PfcRepationshipTranslator, PfcRelationshipUpdater
 from maim_message import UserInfo, Seg
-from ..pfc_relationship import PfcRepationshipTranslator
 from rich.traceback import install
+from bson.decimal128 import Decimal128
 
 install(extra_lines=3)
 
 logger = get_logger("pfc_idle_chat")
-
 
 class IdleChat:
     """主动聊天组件（测试中）
@@ -45,6 +43,12 @@ class IdleChat:
     _pending_replies: Dict[str, float] = {}  # 用户名 -> 发送时间
     _tried_users: Set[str] = set()  # 已尝试过的用户集合
     _global_lock = asyncio.Lock()  # 保护共享状态的全局锁
+    _initialization_task = None  # 初始化任务
+    
+    # 全局共享时间状态
+    _last_global_trigger_time: float = time.time() - 2000  # 最后一次全局触发时间，初始设为过去时间
+    _global_active_instances_count: int = 0  # 全局活跃实例计数
+    _global_check_task = None  # 全局检查任务
 
     @classmethod
     def get_instance(cls, stream_id: str, private_name: str) -> "IdleChat":
@@ -61,9 +65,278 @@ class IdleChat:
         if key not in cls._instances:
             cls._instances[key] = cls(stream_id, private_name)
             # 创建实例时自动启动检测
-            cls._instances[key].start()
-            logger.info(f"[私聊][{private_name}]创建新的IdleChat实例并启动")
+            # cls._instances[key].start()  # 不再启动独立检测，改为全局检测
+            logger.info(f"[私聊][{private_name}]创建新的IdleChat实例")
         return cls._instances[key]
+
+    @classmethod
+    async def start_global_check(cls):
+        """启动全局检查任务，所有实例共享一个时间判断"""
+        if cls._global_check_task is None or cls._global_check_task.done():
+            cls._global_check_task = asyncio.create_task(cls._global_check_loop())
+            logger.info("已启动全局主动聊天检查任务")
+    
+    @classmethod
+    async def _global_check_loop(cls):
+        """全局检查循环，替代各实例独立的检查循环"""
+        try:
+            check_interval = global_config.pfc.idle_check_interval * 60  # 检查间隔（默认10分钟，转换为秒）
+            min_cooldown = global_config.pfc.min_cooldown  # 最短冷却时间
+            max_cooldown = global_config.pfc.max_cooldown  # 最长冷却时间
+            active_hours_start = 6  # 活动开始时间
+            active_hours_end = 24  # 活动结束时间
+            
+            while True:
+                # 检查是否启用了主动聊天功能
+                if not global_config.pfc.enable_idle_chat:
+                    logger.debug("主动聊天功能已禁用，等待启用")
+                    await asyncio.sleep(60)  # 每分钟检查一次配置变更
+                    continue
+                
+                # 获取可用的实例列表
+                active_instances = list(cls._instances.values())
+                if not active_instances:
+                    logger.debug("暂无可用的主动聊天实例，等待下一次检查")
+                    await asyncio.sleep(check_interval)
+                    continue
+                
+                # 检查是否在活动时间内
+                current_hour = datetime.now().hour
+                if not (active_hours_start <= current_hour < active_hours_end):
+                    logger.debug(f"当前时间 {current_hour}:00 不在活动时间内 ({active_hours_start}:00-{active_hours_end}:00)，等待下一次检查")
+                    await asyncio.sleep(check_interval)
+                    continue
+                
+                # 检查是否有活跃实例
+                if cls._global_active_instances_count > 0:
+                    logger.debug(f"存在活跃实例 ({cls._global_active_instances_count})，不触发主动聊天")
+                    await asyncio.sleep(check_interval)
+                    continue
+                
+                # 检查冷却时间
+                current_time = time.time()
+                time_since_last_trigger = current_time - cls._last_global_trigger_time
+                if time_since_last_trigger < min_cooldown:
+                    time_left = min_cooldown - time_since_last_trigger
+                    logger.debug(f"全局冷却时间未到(已过{time_since_last_trigger:.0f}秒/需要{min_cooldown}秒)，还需等待{time_left:.0f}秒")
+                    await asyncio.sleep(min(time_left + 1, check_interval))  # 等待剩余冷却时间或检查间隔，取较小值
+                    continue
+                
+                # 基础几率
+                base_trigger_probability = 0.3
+                
+                # 强制触发检查 - 如果超过最大冷却时间，增加触发概率
+                if time_since_last_trigger > max_cooldown * 2:
+                    force_probability = min(0.8, base_trigger_probability * 3)
+                    if random.random() < force_probability:
+                        logger.info(f"超过最大冷却时间({time_since_last_trigger:.0f}秒)，强制触发主动聊天选择")
+                        selected_instance = await cls._select_instance_to_trigger(active_instances)
+                        if selected_instance:
+                            logger.info(f"选择了实例 {selected_instance.private_name} 进行主动聊天，立即启动")
+                            # 更新全局触发时间
+                            cls._last_global_trigger_time = time.time()
+                            # 创建任务执行聊天，避免阻塞检查循环
+                            asyncio.create_task(selected_instance._initiate_chat())
+                            cls._last_global_trigger_time = time.time()
+                            await asyncio.sleep(check_interval)
+                            continue
+                
+                # 正常触发检查
+                should_trigger = random.random() < base_trigger_probability
+                if should_trigger:
+                    logger.info("随机触发主动聊天检查，开始选择实例")
+                    selected_instance = await cls._select_instance_to_trigger(active_instances)
+                    if selected_instance:
+                        logger.info(f"选择了实例 {selected_instance.private_name} 进行主动聊天，立即启动")
+                        # 更新全局触发时间
+                        cls._last_global_trigger_time = time.time()
+                        # 创建任务执行聊天，避免阻塞检查循环
+                        asyncio.create_task(selected_instance._initiate_chat())
+                
+                # 等待下一次检查
+                await asyncio.sleep(check_interval)
+                
+        except asyncio.CancelledError:
+            logger.debug("全局主动聊天检测任务被取消")
+        except Exception as e:
+            logger.error(f"全局主动聊天检测出错: {str(e)}")
+            logger.error(traceback.format_exc())
+            # 尝试重新启动检测循环
+            cls._global_check_task = asyncio.create_task(cls._global_check_loop())
+    
+    @classmethod
+    async def _select_instance_to_trigger(cls, instances: List["IdleChat"]) -> Optional["IdleChat"]:
+        """基于关系值和其他因素选择一个实例来触发主动聊天
+        
+        Returns:
+            Optional[IdleChat]: 选定的实例，如果没有合适的实例则返回None
+        """
+        if not instances:
+            return None
+        
+        try:
+            logger.info(f"开始选择实例，共有 {len(instances)} 个候选实例")
+            # 获取并记录所有实例的关系值
+            instances_with_rel = []
+            for instance in instances:
+                try:
+                    # 查看是否在待回复列表中
+                    in_pending = instance.private_name in cls._pending_replies
+                    
+                    # 获取关系数据
+                    try:
+                        platform = "qq"  # 假设用户来自QQ平台
+                        rel_value, rel_level_num, rel_level_name = await relationship_manager.get_relationship_data(platform, instance.private_name)
+                        logger.debug(f"实例 {instance.private_name} 的关系数据: 值={rel_value:.2f}, 等级={rel_level_name}")
+                    except Exception as e:
+                        logger.warning(f"获取实例 {instance.private_name} 的关系数据失败: {str(e)}")
+                        # 使用默认值
+                        rel_level_num = 2
+                        rel_value = 0.0
+                    
+                    # 记录实例信息
+                    instances_with_rel.append({
+                        "instance": instance,
+                        "rel_value": rel_value,
+                        "rel_level": rel_level_num,
+                        "in_pending": in_pending,
+                        "weight": 0  # 初始权重为0
+                    })
+                    
+                except Exception as e:
+                    logger.error(f"处理实例 {instance.private_name} 时出错: {str(e)}")
+                    logger.error(traceback.format_exc())
+            
+            # 如果没有获取到有效数据，随机选择一个实例
+            if not instances_with_rel:
+                logger.warning(f"没有任何有效实例，将随机选择一个")
+                return random.choice(instances)
+            
+            logger.info(f"成功获取 {len(instances_with_rel)} 个实例的数据")
+            
+            # 计算每个实例的权重
+            for data in instances_with_rel:
+                # 基础权重：关系等级0=1, 1=2, 2=3, 3=4, 4=5, 5=6
+                base_weight = data["rel_level"] + 1
+                
+                # 如果在待回复列表中，大幅降低权重
+                if data["in_pending"]:
+                    base_weight *= 0.1
+                
+                # 最终权重
+                data["weight"] = base_weight
+                logger.debug(f"实例 {data['instance'].private_name} 的权重: {data['weight']}")
+            
+            # 按权重进行加权随机选择
+            total_weight = sum(data["weight"] for data in instances_with_rel)
+            if total_weight <= 0:
+                # 如果所有权重都是0，随机选择
+                logger.warning(f"所有实例的权重都为0，将随机选择一个实例")
+                selected = random.choice(instances_with_rel)
+            else:
+                # 加权随机选择
+                rand_val = random.uniform(0, total_weight)
+                current = 0
+                selected = instances_with_rel[0]
+                for data in instances_with_rel:
+                    current += data["weight"]
+                    if rand_val <= current:
+                        selected = data
+                        break
+            
+            logger.info(f"选择了用户 {selected['instance'].private_name} 进行主动聊天")
+            return selected["instance"]
+            
+        except Exception as e:
+            logger.error(f"选择实例时出错: {str(e)}")
+            logger.error(traceback.format_exc())
+            # 出错时随机选择一个实例
+            logger.warning(f"由于错误，将随机选择一个实例")
+            return random.choice(instances)
+
+    @classmethod
+    async def initialize_all_streams(cls):
+        """初始化所有可用的聊天流的主动聊天功能
+        
+        从数据库加载所有聊天流，并为每个私聊流创建一个IdleChat实例
+        """
+        try:
+            logger.info("开始初始化所有可用聊天流的主动聊天功能")
+            
+            # 获取所有聊天流 - 使用现有的load_all_streams方法
+            await chat_manager.load_all_streams()
+            all_streams = chat_manager.streams
+            
+            logger.info(f"共加载 {len(all_streams)} 个聊天流，开始筛选私聊流")
+            
+            # 改进私聊流的识别逻辑 - 基于ChatStream对象的属性而非stream_id
+            private_streams = {}
+            for stream_id, stream in all_streams.items():
+                # 详细日志记录当前流信息，帮助调试
+                stream_info = f"ID: {stream_id}"
+                if hasattr(stream, "user_info") and stream.user_info:
+                    stream_info += f", user: {stream.user_info.user_nickname if hasattr(stream.user_info, 'user_nickname') else 'None'}"
+                if hasattr(stream, "group_info") and stream.group_info:
+                    stream_info += f", group: {stream.group_info.group_name if hasattr(stream.group_info, 'group_name') else 'None'}"
+                logger.debug(f"检查流: {stream_info}")
+                
+                # 私聊判断标准: 有user_info但没有group_info
+                if (hasattr(stream, "user_info") and stream.user_info and 
+                    (not hasattr(stream, "group_info") or stream.group_info is None)):
+                    logger.info(f"找到私聊流: {stream_info}")
+                    private_streams[stream_id] = stream
+                # 备用判断: 流ID中包含私聊相关标识
+                elif stream_id and isinstance(stream_id, str) and ("private" in stream_id.lower() or "direct" in stream_id.lower()):
+                    logger.info(f"基于ID找到可能的私聊流: {stream_info}")
+                    private_streams[stream_id] = stream
+            
+            logger.info(f"找到 {len(private_streams)} 个私聊流，开始创建IdleChat实例")
+            
+            # 为每个私聊流创建IdleChat实例
+            for stream_id, stream in private_streams.items():
+                try:
+                    # 获取私聊用户名称
+                    private_name = None
+                    
+                    # 尝试获取用户昵称或ID
+                    if hasattr(stream, "user_info") and stream.user_info:
+                        if hasattr(stream.user_info, "user_nickname") and stream.user_info.user_nickname:
+                            private_name = stream.user_info.user_nickname
+                        elif hasattr(stream.user_info, "user_id") and stream.user_info.user_id:
+                            private_name = str(stream.user_info.user_id)
+                    
+                    # 如果无法从user_info获取名称，尝试从stream_id解析
+                    if not private_name and stream_id and isinstance(stream_id, str):
+                        # 尝试各种可能的格式解析
+                        if "_" in stream_id:
+                            parts = stream_id.split("_")
+                            # 尝试找到可能是用户ID的部分
+                            for part in parts:
+                                if part.isdigit() or (part and not any(kw in part.lower() for kw in ["private", "direct", "chat"])):
+                                    private_name = part
+                                    break
+                    
+                    # 如果仍无法获取名称，使用stream_id作为最后手段
+                    if not private_name:
+                        private_name = stream_id
+                        logger.warning(f"无法获取流 {stream_id} 的用户名称，使用stream_id作为替代")
+                    
+                    # 创建IdleChat实例
+                    cls.get_instance(stream_id, private_name)
+                    logger.info(f"为用户 {private_name} 创建了IdleChat实例")
+                except Exception as e:
+                    logger.error(f"为流 {stream_id} 创建IdleChat实例时出错: {str(e)}")
+                    logger.error(traceback.format_exc())
+            
+            logger.success(f"所有可用聊天流的主动聊天功能初始化完成，共创建 {len(private_streams)} 个实例")
+            
+            # 启动全局检查任务
+            await cls.start_global_check()
+            logger.info("已启动全局主动聊天检查任务")
+            
+        except Exception as e:
+            logger.error(f"初始化所有聊天流时出错: {str(e)}")
+            logger.error(traceback.format_exc())
 
     @classmethod
     async def register_user_response(cls, private_name: str) -> None:
@@ -90,7 +363,7 @@ class IdleChat:
         """
         async with cls._global_lock:
             current_time = time.time()
-            timeout_threshold = 7200  # 2小时未回复视为超时
+            timeout_threshold = 120 # 500秒未回复视为超时
 
             # 清理超时未回复的用户
             for user, send_time in list(cls._pending_replies.items()):
@@ -135,73 +408,46 @@ class IdleChat:
         self.private_name = private_name
         self.chat_observer = ChatObserver.get_instance(stream_id, private_name)
         self.message_sender = DirectMessageSender(private_name)
-
-        # 添加异步锁，保护对共享变量的访问
-        self._lock: asyncio.Lock = asyncio.Lock()
+        
+        # 初始化关系组件
+        self.relationship_translator = PfcRepationshipTranslator(private_name)
+        self.relationship_updater = PfcRelationshipUpdater(private_name, global_config.bot.nickname)
 
         # LLM请求对象，用于生成主动对话内容
         self.llm = LLMRequest(model=global_config.model.normal, temperature=0.5, max_tokens=500, request_type="idle_chat")
-
-        # 工作状态
-        self.active_instances_count: int = 0
-        self.last_trigger_time: float = time.time() - 1500  # 初始化时减少等待时间
-        self._running: bool = False
-        self._task: Optional[asyncio.Task] = None
 
         # 配置参数 - 从global_config加载
         self.min_cooldown = global_config.pfc.min_cooldown  # 最短冷却时间（默认2小时）
         self.max_cooldown = global_config.pfc.max_cooldown  # 最长冷却时间（默认5小时）
         self.check_interval = global_config.pfc.idle_check_interval * 60  # 检查间隔（默认10分钟，转换为秒）
-        self.active_hours_start = 7  # 活动开始时间
-        self.active_hours_end = 23  # 活动结束时间
-
-        # 关系值相关
-        self.base_trigger_probability = 0.3  # 基础触发概率
-        self.relationship_factor = 0.0003  # 关系值影响因子
+        self.active_hours_start = 6  # 活动开始时间
+        self.active_hours_end = 24  # 活动结束时间
 
     def start(self) -> None:
         """启动主动聊天检测"""
-        # 检查是否启用了主动聊天功能
-        if not global_config.pfc.enable_idle_chat:
-            logger.info(f"[私聊][{self.private_name}]主动聊天功能已禁用（配置enable_idle_chat=False）")
-            return
-
-        if self._running:
-            logger.debug(f"[私聊][{self.private_name}]主动聊天功能已在运行中")
-            return
-
-        self._running = True
-        self._task = asyncio.create_task(self._check_idle_loop())
-        logger.info(f"[私聊][{self.private_name}]启动主动聊天检测")
+        logger.info(f"[私聊][{self.private_name}]主动聊天功能已通过全局检测机制启动")
 
     def stop(self) -> None:
         """停止主动聊天检测"""
-        if not self._running:
-            return
-
-        self._running = False
-        if self._task:
-            self._task.cancel()
-            self._task = None
-        logger.info(f"[私聊][{self.private_name}]停止主动聊天检测")
+        logger.info(f"[私聊][{self.private_name}]主动聊天功能已停止")
 
     async def increment_active_instances(self) -> None:
         """增加活跃实例计数
 
         当创建新的对话实例时调用此方法
         """
-        async with self._lock:
-            self.active_instances_count += 1
-            logger.debug(f"[私聊][{self.private_name}]活跃实例数+1，当前：{self.active_instances_count}")
+        async with self.__class__._global_lock:
+            self.__class__._global_active_instances_count += 1
+            logger.debug(f"[私聊][{self.private_name}]全局活跃实例数+1，当前：{self.__class__._global_active_instances_count}")
 
     async def decrement_active_instances(self) -> None:
         """减少活跃实例计数
 
         当对话实例结束时调用此方法
         """
-        async with self._lock:
-            self.active_instances_count = max(0, self.active_instances_count - 1)
-            logger.debug(f"[私聊][{self.private_name}]活跃实例数-1，当前：{self.active_instances_count}")
+        async with self.__class__._global_lock:
+            self.__class__._global_active_instances_count = max(0, self.__class__._global_active_instances_count - 1)
+            logger.debug(f"[私聊][{self.private_name}]全局活跃实例数-1，当前：{self.__class__._global_active_instances_count}")
 
     async def update_last_message_time(self, message_time: Optional[float] = None) -> None:
         """更新最后一条消息的时间
@@ -209,219 +455,12 @@ class IdleChat:
         Args:
             message_time: 消息时间戳，如果为None则使用当前时间
         """
-        async with self._lock:
-            self.last_trigger_time = message_time or time.time()
-            logger.debug(f"[私聊][{self.private_name}]更新最后消息时间: {self.last_trigger_time:.2f}")
+        async with self.__class__._global_lock:
+            self.__class__._last_global_trigger_time = message_time or time.time()
+            logger.debug(f"[私聊][{self.private_name}]更新全局最后消息时间: {self.__class__._last_global_trigger_time:.2f}")
 
         # 当用户发送消息时，也应该注册响应
         await self.__class__.register_user_response(self.private_name)
-
-    def _is_active_hours(self) -> bool:
-        """检查是否在活动时间内"""
-        current_hour = datetime.now().hour
-        return self.active_hours_start <= current_hour < self.active_hours_end
-
-    async def _should_trigger(self) -> bool:
-        """检查是否应该触发主动聊天"""
-        async with self._lock:
-            # 确保计数不会出错，重置为0如果发现是负数
-            if self.active_instances_count < 0:
-                logger.warning(f"[私聊][{self.private_name}]检测到活跃实例数为负数，重置为0")
-                self.active_instances_count = 0
-
-            # 检查是否有活跃实例
-            if self.active_instances_count > 0:
-                logger.debug(f"[私聊][{self.private_name}]存在活跃实例({self.active_instances_count})，不触发主动聊天")
-                return False
-
-            # 检查是否在活动时间内
-            if not self._is_active_hours():
-                logger.debug(f"[私聊][{self.private_name}]不在活动时间内，不触发主动聊天")
-                return False
-
-            # 检查冷却时间
-            current_time = time.time()
-            time_since_last_trigger = current_time - self.last_trigger_time
-            if time_since_last_trigger < self.min_cooldown:
-                time_left = self.min_cooldown - time_since_last_trigger
-                logger.debug(
-                    f"[私聊][{self.private_name}]冷却时间未到(已过{time_since_last_trigger:.0f}秒/需要{self.min_cooldown}秒)，还需等待{time_left:.0f}秒，不触发主动聊天"
-                )
-                return False
-
-            # 强制触发检查 - 如果超过最大冷却时间，增加触发概率
-            force_trigger = False
-            if time_since_last_trigger > self.max_cooldown * 2:  # 如果超过最大冷却时间的两倍
-                force_probability = min(0.6, self.base_trigger_probability * 2)  # 增加概率但不超过0.6
-                random_force = random.random()
-                force_trigger = random_force < force_probability
-                if force_trigger:
-                    logger.info(
-                        f"[私聊][{self.private_name}]超过最大冷却时间({time_since_last_trigger:.0f}秒)，强制触发主动聊天"
-                    )
-                    return True
-
-            # 获取关系值
-            relationship_value = 0
-            try:
-                # 尝试获取person_id
-                person_id = None
-                try:
-                    # 先尝试通过昵称获取person_id
-                    platform = "qq"  # 默认平台
-                    person_id = person_info_manager.get_person_id(platform, self.private_name)
-
-                    # 如果通过昵称获取失败，尝试通过stream_id解析
-                    if not person_id:
-                        parts = self.stream_id.split("_")
-                        if len(parts) >= 2 and parts[0] == "private":
-                            user_id = parts[1]
-                            platform = parts[2] if len(parts) >= 3 else "qq"
-                            try:
-                                person_id = person_info_manager.get_person_id(platform, int(user_id))
-                            except ValueError:
-                                # 如果user_id不是整数，尝试作为字符串使用
-                                person_id = person_info_manager.get_person_id(platform, user_id)
-                except Exception as e2:
-                    logger.warning(f"[私聊][{self.private_name}]尝试获取person_id失败: {str(e2)}")
-
-                # 获取关系值
-                if person_id:
-                    raw_value = await person_info_manager.get_value(person_id, "relationship_value")
-                    relationship_value = relationship_manager.ensure_float(raw_value, person_id)
-                    logger.debug(f"[私聊][{self.private_name}]成功获取关系值: {relationship_value}")
-                else:
-                    logger.warning(f"[私聊][{self.private_name}]无法获取person_id，使用默认关系值0")
-
-                # 使用PfcRepationshipTranslator获取关系描述
-                relationship_translator = PfcRepationshipTranslator(self.private_name)
-                relationship_level = relationship_translator._calculate_relationship_level_num(
-                    relationship_value, self.private_name
-                )
-
-                # 基于关系等级调整触发概率
-                # 关系越好，主动聊天概率越高
-                level_probability_factors = [0.05, 0.1, 0.2, 0.3, 0.4, 0.5]  # 每个等级对应的基础概率因子
-                base_probability = level_probability_factors[relationship_level]
-
-                # 基础概率因子
-                trigger_probability = base_probability
-                trigger_probability = max(0.05, min(0.6, trigger_probability))  # 限制在0.05-0.6之间
-
-                # 最大冷却时间调整 - 随着冷却时间增加，逐渐增加触发概率
-                if time_since_last_trigger > self.max_cooldown:
-                    # 计算额外概率 - 每超过最大冷却时间的10%，增加1%的概率，最多增加30%
-                    extra_time_factor = min(
-                        0.3, (time_since_last_trigger - self.max_cooldown) / (self.max_cooldown * 10)
-                    )
-                    trigger_probability += extra_time_factor
-                    logger.debug(f"[私聊][{self.private_name}]超过标准冷却时间，额外增加概率: +{extra_time_factor:.2f}")
-
-                # 随机判断是否触发
-                random_value = random.random()
-                should_trigger = random_value < trigger_probability
-                logger.debug(
-                    f"[私聊][{self.private_name}]触发概率计算: 基础({base_probability:.2f}) + 关系值({relationship_value})影响 = {trigger_probability:.2f}，随机值={random_value:.2f}, 结果={should_trigger}"
-                )
-
-                # 如果决定触发，记录详细日志
-                if should_trigger:
-                    logger.info(
-                        f"[私聊][{self.private_name}]决定触发主动聊天: 触发概率={trigger_probability:.2f}, 距上次已过{time_since_last_trigger:.0f}秒"
-                    )
-
-                return should_trigger
-
-            except Exception as e:
-                logger.error(f"[私聊][{self.private_name}]获取关系值失败: {str(e)}")
-                logger.error(traceback.format_exc())
-
-                # 即使获取关系值失败，仍有一个基础的几率触发
-                # 这确保即使数据库有问题，主动聊天功能仍然可用
-                base_fallback_probability = 0.1  # 较低的基础几率
-                random_fallback = random.random()
-                fallback_trigger = random_fallback < base_fallback_probability
-                if fallback_trigger:
-                    logger.info(
-                        f"[私聊][{self.private_name}]获取关系值失败，使用后备触发机制: 概率={base_fallback_probability:.2f}, 决定={fallback_trigger}"
-                    )
-                return fallback_trigger
-
-    async def _check_idle_loop(self) -> None:
-        """检查空闲状态的循环"""
-        try:
-            while self._running:
-                # 检查是否启用了主动聊天功能
-                if not global_config.pfc.enable_idle_chat:
-                    # 如果禁用了功能，等待一段时间后再次检查配置
-                    await asyncio.sleep(60)  # 每分钟检查一次配置变更
-                    continue
-
-                # 检查当前用户是否应该触发主动聊天
-                should_trigger = await self._should_trigger()
-
-                # 如果当前用户不触发，检查是否有其他用户已经超时未回复
-                if not should_trigger:
-                    async with self.__class__._global_lock:
-                        current_time = time.time()
-                        pending_timeout = 1800  # 30分钟未回复检查
-
-                        # 检查此用户是否在等待回复列表中
-                        if self.private_name in self.__class__._pending_replies:
-                            logger.debug(f"[私聊][{self.private_name}]当前用户在等待回复列表中，不进行额外检查")
-                        else:
-                            # 查找所有超过30分钟未回复的用户
-                            timed_out_users = []
-                            for user, send_time in self.__class__._pending_replies.items():
-                                if current_time - send_time > pending_timeout:
-                                    timed_out_users.append(user)
-
-                            # 如果有超时未回复的用户，尝试找下一个用户
-                            if timed_out_users:
-                                logger.info(f"[私聊]发现{len(timed_out_users)}个用户超过{pending_timeout}秒未回复")
-                                next_user = await self.__class__.get_next_available_user()
-
-                                if next_user and next_user != self.private_name:
-                                    logger.info(f"[私聊]选择下一个用户[{next_user}]进行主动聊天")
-                                    # 查找该用户的实例并触发聊天
-                                    for key, instance in self.__class__._instances.items():
-                                        if key.startswith(f"{next_user}:"):
-                                            logger.info(f"[私聊]为用户[{next_user}]触发主动聊天")
-                                            # 触发该实例的主动聊天
-                                            asyncio.create_task(instance._initiate_chat())
-                                            break
-
-                # 如果当前用户应该触发主动聊天
-                if should_trigger:
-                    try:
-                        await self._initiate_chat()
-                        # 更新上次触发时间
-                        async with self._lock:
-                            self.last_trigger_time = time.time()
-
-                        # 将此用户添加到等待回复列表中
-                        async with self.__class__._global_lock:
-                            self.__class__._pending_replies[self.private_name] = time.time()
-                            self.__class__._tried_users.add(self.private_name)
-                            logger.info(f"[私聊][{self.private_name}]已添加到等待回复列表中")
-                    except Exception as e:
-                        logger.error(f"[私聊][{self.private_name}]执行主动聊天过程出错: {str(e)}")
-                        logger.error(traceback.format_exc())
-
-                # 等待下一次检查
-                check_interval = self.check_interval  # 使用配置的检查间隔
-                logger.debug(f"[私聊][{self.private_name}]等待{check_interval}秒后进行下一次主动聊天检查")
-                await asyncio.sleep(check_interval)
-
-        except asyncio.CancelledError:
-            logger.debug(f"[私聊][{self.private_name}]主动聊天检测任务被取消")
-        except Exception as e:
-            logger.error(f"[私聊][{self.private_name}]主动聊天检测出错: {str(e)}")
-            logger.error(traceback.format_exc())
-            # 尝试重新启动检测循环
-            if self._running:
-                logger.info(f"[私聊][{self.private_name}]尝试重新启动主动聊天检测")
-                self._task = asyncio.create_task(self._check_idle_loop())
 
     async def _get_chat_stream(self) -> Optional[ChatStream]:
         """获取聊天流实例"""
@@ -455,46 +494,44 @@ class IdleChat:
         try:
             # 获取聊天历史记录
             messages = self.chat_observer.get_cached_messages(limit=12)
+            
+            # 立即获取历史文本
             chat_history_text = await build_readable_messages(
                 messages, replace_bot_name=True, merge_messages=False, timestamp_mode="relative", read_mark=0.0
             )
-
-            # 获取关系值
-            relationship_value = 0
+            
+            # 添加触发判定条件
+            # 1. 检查是否有活跃对话实例存在
+            if self.__class__._global_active_instances_count > 0:
+                logger.debug(f"[私聊][{self.private_name}]存在活跃实例，取消主动聊天")
+                return
+            
+            # 2. 检查是否在待回复列表中
+            if self.private_name in self.__class__._pending_replies:
+                logger.debug(f"[私聊][{self.private_name}]已在待回复列表中，取消主动聊天")
+                return
+                
+            # 此时已通过所有条件判断，可以继续生成和发送消息
+            logger.info(f"[私聊][{self.private_name}]通过所有触发条件，开始准备主动聊天内容")
+            
+            # 获取关系数据
             try:
-                platform = "qq"
-                person_id = person_info_manager.get_person_id(platform, self.private_name)
-                if person_id:
-                    raw_value = await person_info_manager.get_value(person_id, "relationship_value")
-                    relationship_value = relationship_manager.ensure_float(raw_value, person_id)
+                platform = "qq"  # 假设用户来自QQ平台
+                rel_value, rel_level_num, rel_level_name = await relationship_manager.get_relationship_data(platform, self.private_name)
+                logger.info(f"[私聊][{self.private_name}]关系值: {rel_value:.2f}, 关系等级: {rel_level_name}")
+                relationship_description = rel_level_name
             except Exception as e:
-                logger.warning(f"[私聊][{self.private_name}]获取关系值失败，使用默认值: {e}")
-
-            # 使用PfcRepationshipTranslator获取关系描述
-            relationship_translator = PfcRepationshipTranslator(self.private_name)
-            full_relationship_text = await relationship_translator.translate_relationship_value_to_text(
-                relationship_value
-            )
-
-            # 提取纯关系描述（去掉"你们的关系是："前缀）
-            relationship_description = "普通"  # 默认值
-            if "：" in full_relationship_text:
-                relationship_description = full_relationship_text.split("：")[1].replace("。", "")
-
-            # 暂不使用
-            # if global_config.schedule.enable:
-            #     schedule_prompt = await global_prompt_manager.format_prompt(
-            #         "schedule_prompt", schedule_info=bot_schedule.get_current_num_task(num=1, time_info=False)
-            #     )
-            # else:
-            #     schedule_prompt = ""
-
-            # 构建提示词，暂存废弃部分这是你的日程{schedule_prompt}
+                logger.error(f"[私聊][{self.private_name}]获取关系数据失败: {str(e)}")
+                logger.error(traceback.format_exc())
+                # 使用默认关系描述
+                relationship_description = "普通"
+            
+            # 构建提示词
             current_time = datetime.now().strftime("%H:%M")
             prompt = f"""你是{global_config.bot.nickname}。
             你正在与用户{self.private_name}进行QQ私聊，你们的关系是{relationship_description}
             现在时间{current_time}
-
+            
             你想要主动发起对话。
             请基于以下之前的对话历史，生成一条自然、友好、符合关系程度的主动对话消息。
             这条消息应能够引起用户的兴趣，重新开始对话。
@@ -517,7 +554,7 @@ class IdleChat:
                 logger.error(f"[私聊][{self.private_name}]生成主动聊天内容失败: {str(llm_err)}")
                 logger.error(traceback.format_exc())
                 return
-
+                
             # 清理结果
             content = content.strip()
             content = content.strip("\"'")
@@ -540,10 +577,35 @@ class IdleChat:
                     chat_stream=chat_stream, segments=segments, reply_to_message=None, content=content
                 )
                 logger.info(f"[私聊][{self.private_name}]成功主动发起聊天: {content}")
+                
+                # 将此用户添加到待回复列表
+                async with self.__class__._global_lock:
+                    self.__class__._pending_replies[self.private_name] = time.time()
+                    self.__class__._tried_users.add(self.private_name)
+                    logger.info(f"[私聊][{self.private_name}]已添加到等待回复列表中")
+                
             except Exception as e:
                 logger.error(f"[私聊][{self.private_name}]发送主动聊天消息失败: {str(e)}")
                 logger.error(traceback.format_exc())
-
+                
         except Exception as e:
             logger.error(f"[私聊][{self.private_name}]主动发起聊天过程中发生未预期的错误: {str(e)}")
             logger.error(traceback.format_exc())
+
+# 启动自动初始化任务
+if __name__ == "__main__":
+    asyncio.run(IdleChat.initialize_all_streams())
+else:
+    # 在导入时，使用create_task异步启动，避免阻塞导入过程
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            # 如果事件循环正在运行，则创建任务
+            asyncio.create_task(IdleChat.initialize_all_streams())
+            logger.info("已在现有事件循环中启动主动聊天初始化任务")
+        else:
+            # 如果事件循环未运行，则需要另外处理
+            logger.info("事件循环未运行，将在适当时机启动主动聊天初始化任务")
+            # 可以在这里添加稍后启动的逻辑，或者由外部调用 IdleChat.start_initialization_task()
+    except RuntimeError:
+        logger.warning("无法获取事件循环，将由外部调用启动主动聊天初始化任务")

--- a/src/experimental/PFC/PFC_idle/idle_weight.py
+++ b/src/experimental/PFC/PFC_idle/idle_weight.py
@@ -1,0 +1,292 @@
+"""
+权重计算模块 - 为主动聊天功能提供权重和触发概率计算
+
+此模块包含：
+1. 基于关系等级的权重计算函数
+2. 根据关系调整触发概率的函数
+"""
+from typing import Dict, Any, List, Tuple, Optional
+import logging
+import traceback
+
+# 获取日志记录器
+logger = logging.getLogger("pfc_idle_chat")
+
+# 导入关系管理器
+from src.chat.person_info.person_info import person_info_manager
+from src.chat.person_info.relationship_manager import relationship_manager
+
+# 关系等级范围，用于替代直接访问relationship_manager.level_ranges
+DEFAULT_LEVEL_RANGES = [-100, -50, 0, 50, 100, 150]
+
+def get_relationship_level_ranges() -> List[float]:
+    """获取关系等级的阈值范围
+    
+    Returns:
+        List[float]: 关系等级的阈值范围列表
+    """
+    try:
+        # 尝试从relationship_manager获取level_ranges属性
+        if hasattr(relationship_manager, 'level_ranges'):
+            return relationship_manager.level_ranges
+        
+        # 如果没有这个属性，使用默认值
+        logger.warning("RelationshipManager对象没有level_ranges属性，使用默认值")
+        return DEFAULT_LEVEL_RANGES
+    except Exception as e:
+        logger.error(f"获取关系等级范围时出错: {str(e)}")
+        logger.error(traceback.format_exc())
+        return DEFAULT_LEVEL_RANGES
+
+def calculate_user_weight(
+    relationship_level: int, 
+    relationship_value: float, 
+    level_ranges: List[float] = None, 
+    in_pending: bool = False
+) -> float:
+    """计算用户的权重，用于主动聊天的用户选择
+
+    Args:
+        relationship_level: 关系等级 (0=厌恶, 1=冷漠, 2=一般, 3=友好, 4=喜欢, 5=依赖)
+        relationship_value: 精确关系值
+        level_ranges: 关系等级的范围边界值列表，默认为None时自动获取
+        in_pending: 是否在待回复列表中，默认为False
+
+    Returns:
+        float: 计算得到的权重值
+    """
+    # 如果未提供等级范围，则自动获取
+    if level_ranges is None:
+        level_ranges = get_relationship_level_ranges()
+        
+    # 对关系等级应用指数增长权重，让高关系等级的用户有明显更高的权重
+    if relationship_level <= 1:  # 厌恶和冷漠
+        # 低关系给予较低的权重，但仍有一定概率被选中
+        base_weight = max(0.3, 0.5 * (relationship_level + 1))
+    elif relationship_level == 2:  # 一般
+        # 中等关系
+        base_weight = 2.0
+    elif relationship_level == 3:  # 友好
+        # 友好关系，权重开始显著增加
+        base_weight = 4.0
+    elif relationship_level == 4:  # 喜欢
+        # 喜欢关系，较高权重
+        base_weight = 7.0
+    else:  # 依赖 (relationship_level == 5)
+        # 依赖关系，极高权重
+        base_weight = 12.0
+    
+    # 微调：在同一关系等级内，基于精确关系值进行微调（±20%）
+    if relationship_level < len(level_ranges) - 1:
+        curr_min = level_ranges[relationship_level]
+        next_min = level_ranges[relationship_level + 1]
+        # 计算在当前等级内的相对位置 (0.0 到 1.0)
+        if next_min > curr_min:
+            relative_pos = min(1.0, max(0.0, (relationship_value - curr_min) / (next_min - curr_min)))
+            # 应用±20%的微调
+            fine_tune_factor = 0.8 + (0.4 * relative_pos)  # 0.8 到 1.2
+            base_weight *= fine_tune_factor
+    
+    # 如果在待回复列表中，降低权重
+    if in_pending:
+        base_weight *= 0.1
+    
+    return base_weight
+
+def calculate_base_trigger_probability(relationship_level: int) -> float:
+    """基于关系等级计算基础触发概率
+
+    Args:
+        relationship_level: 关系等级 (0=厌恶, 1=冷漠, 2=一般, 3=友好, 4=喜欢, 5=依赖)
+
+    Returns:
+        float: 基础触发概率
+    """
+    # 基础触发概率，基于关系等级动态调整
+    probability_map = {
+        0: 0.1,   # 厌恶
+        1: 0.15,  # 冷漠
+        2: 0.25,  # 一般
+        3: 0.35,  # 友好
+        4: 0.45,  # 喜欢
+        5: 0.6    # 依赖
+    }
+    return probability_map.get(relationship_level, 0.3)
+
+def process_instances_weights(
+    instances_with_rel: List[Dict[str, Any]],
+    level_ranges: List[float] = None
+) -> None:
+    """处理所有实例的权重计算
+
+    Args:
+        instances_with_rel: 包含实例和关系数据的列表
+        level_ranges: 关系等级的范围边界值列表，默认为None时自动获取
+    """
+    # 如果未提供等级范围，则自动获取
+    if level_ranges is None:
+        level_ranges = get_relationship_level_ranges()
+        
+    # 计算每个实例的权重
+    for data in instances_with_rel:
+        # 获取关系数据
+        relationship_level = data["relationship_level"]
+        relationship_value = data["relationship_value"]
+        in_pending = data["in_pending"]
+        
+        # 计算权重
+        base_weight = calculate_user_weight(
+            relationship_level, 
+            relationship_value, 
+            level_ranges, 
+            in_pending
+        )
+        
+        # 记录日志
+        logger.debug(
+            f"[私聊][{data['instance'].private_name}] "
+            f"关系等级: {relationship_level}, "
+            f"关系值: {relationship_value:.2f}, "
+            f"基础权重: {base_weight:.2f}"
+        )
+        
+        # 最终权重
+        data["weight"] = base_weight
+    
+    # 记录所有用户的权重情况
+    weight_info = "\n".join([
+        f"- {data['instance'].private_name}: "
+        f"关系等级={data['relationship_level']}, "
+        f"权重={data['weight']:.2f}" for data in instances_with_rel
+    ])
+    logger.info(f"所有用户的权重分配:\n{weight_info}")
+
+def find_max_relationship_user(instances_with_rel: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """找出具有最高关系值的用户
+
+    Args:
+        instances_with_rel: 包含实例和关系数据的列表
+
+    Returns:
+        Dict[str, Any]: 最高关系值的用户数据，如果列表为空则返回None
+    """
+    if not instances_with_rel:
+        return None
+    return max(instances_with_rel, key=lambda x: x["relationship_value"])
+
+async def get_user_relationship_data(user_id, platform="qq", private_name=None) -> Tuple[float, int, str]:
+    """获取用户的关系数据
+    
+    Args:
+        user_id: 用户ID
+        platform: 平台，默认为"qq"
+        private_name: 用户名称，用于日志记录
+        
+    Returns:
+        Tuple[float, int, str]: (关系值，关系等级数字，关系等级描述)
+    """
+    try:
+        log_prefix = f"[私聊][{private_name}]" if private_name else "[私聊]"
+        
+        # 默认关系数据
+        relationship_value = 0.0
+        relationship_level_num = 2  # 对应 "一般"
+        relationship_description = "普通"
+        
+        # 生成person_id并获取关系值
+        person_id = person_info_manager.get_person_id(platform, user_id)
+        if private_name:
+            logger.info(f"{log_prefix}生成的person_id: {person_id}")
+        
+        # 使用person_info_manager获取关系值
+        relationship_value = await person_info_manager.get_value(person_id, "relationship_value")
+        if private_name:
+            logger.info(f"{log_prefix}获取到原始关系值: {relationship_value}")
+        
+        # 确保关系值为浮点类型
+        relationship_value = ensure_float_relationship(relationship_value, person_id)
+        
+        # 计算关系等级
+        relationship_level_num = calculate_relationship_level_num(relationship_value)
+        
+        # 获取关系等级描述
+        relationship_level_names = ["厌恶", "冷漠", "一般", "友好", "喜欢", "依赖"]
+        relationship_description = relationship_level_names[relationship_level_num]
+        
+        if private_name:
+            logger.info(f"{log_prefix}关系值: {relationship_value:.2f}, 关系等级: {relationship_description}")
+        
+        return relationship_value, relationship_level_num, relationship_description
+    
+    except Exception as e:
+        if private_name:
+            logger.error(f"[私聊][{private_name}]获取关系数据失败: {str(e)}")
+            logger.error(traceback.format_exc())
+        else:
+            logger.error(f"获取关系数据失败: {str(e)}")
+            logger.error(traceback.format_exc())
+        
+        # 使用默认关系数据
+        return 0.0, 2, "普通"
+
+def ensure_float_relationship(value, person_id=None) -> float:
+    """确保关系值为浮点类型
+    
+    这个函数是对relationship_manager.ensure_float的封装，
+    提供错误处理以防止relationship_manager不存在ensure_float方法
+    
+    Args:
+        value: 关系值
+        person_id: 用户ID，用于日志记录
+        
+    Returns:
+        float: 转换为浮点类型的关系值
+    """
+    try:
+        if hasattr(relationship_manager, 'ensure_float'):
+            return relationship_manager.ensure_float(value, person_id)
+        
+        # 如果relationship_manager没有ensure_float方法，手动实现转换
+        try:
+            # 处理各种可能的类型
+            if hasattr(value, 'value'):  # 处理Decimal128等有value属性的类型
+                return float(value.value)
+            else:
+                return float(value)
+        except (ValueError, TypeError):
+            logger.warning(f"无法将关系值 '{value}' 转换为浮点数，使用默认值0.0")
+            return 0.0
+    except Exception as e:
+        logger.error(f"确保关系值为浮点类型时出错: {str(e)}")
+        logger.error(traceback.format_exc())
+        return 0.0
+
+def calculate_relationship_level_num(relationship_value: float) -> int:
+    """计算关系等级数字
+    
+    这个函数是对relationship_manager.calculate_level_num的封装，
+    提供错误处理以防止relationship_manager不存在calculate_level_num方法
+    
+    Args:
+        relationship_value: 关系值
+        
+    Returns:
+        int: 关系等级数字 (0-5)
+    """
+    try:
+        if hasattr(relationship_manager, 'calculate_level_num'):
+            return relationship_manager.calculate_level_num(relationship_value)
+        
+        # 如果relationship_manager没有calculate_level_num方法，手动实现计算
+        level_ranges = get_relationship_level_ranges()
+        
+        for i in range(len(level_ranges) - 1, -1, -1):
+            if relationship_value >= level_ranges[i]:
+                return i
+        
+        # 如果小于所有范围，返回最低等级
+        return 0
+    except Exception as e:
+        logger.error(f"计算关系等级时出错: {str(e)}")
+        logger.error(traceback.format_exc())
+        return 2  # 默认为"一般" 


### PR DESCRIPTION
## Summary by Sourcery

Introduce a global idle chat auto-start mechanism that initializes IdleChat for all private streams at boot and replaces per-instance loops with a centralized scheduler

New Features:
- Automatically discover all private chat streams and create IdleChat instances at startup
- Start a single global idle-chat check loop that triggers messages based on cooldown, active hours, and relationship
- Select and weight instances for engagement by fetching and translating relationship values

Enhancements:
- Consolidate active instance counts and last trigger time into class-level global state
- Reduce user reply timeout threshold from 2 hours to 120 seconds
- Integrate the idle chat initialization task into bot.py as a delayed AsyncTask
- Simplify start/stop logging and internal locks to reflect the new global scheduling model